### PR TITLE
Added new PID for the White SKU of the H100i Elite AIO

### DIFF
--- a/src/FanControl.CorsairLink/HardwareIds.cs
+++ b/src/FanControl.CorsairLink/HardwareIds.cs
@@ -33,6 +33,7 @@ public static class HardwareIds
     public static readonly int CorsairCommanderCore2022ProductId = 0x0c32;
     public static readonly int CorsairHydroH60iEliteProductId = 0x0c34;
     public static readonly int CorsairHydroH100iEliteProductId = 0x0c35;
+    public static readonly int CorsairHydroH100iEliteWhiteProductId = 0x0c40;
     public static readonly int CorsairHydroH115iEliteProductId = 0x0c36;
     public static readonly int CorsairHydroH150iEliteProductId = 0x0c37;
     public static readonly int CorsairICueLinkHubProductId = 0x0c3f;
@@ -90,6 +91,7 @@ public static class HardwareIds
             CorsairHydroH100iPlatinumSEProductId,
             CorsairHydroH100iProXTProductId,
             CorsairHydroH100iEliteProductId,
+            CorsairHydroH100iEliteWhiteProductId,
             CorsairHydroH115iProXTProductId,
             CorsairHydroH115iPlatinumProductId,
             CorsairHydroH100iProXT2ProductId,


### PR DESCRIPTION
I'm not a software dev.. but I managed to get this into OpenRGB (https://gitlab.com/CalcProgrammer1/OpenRGB/-/merge_requests/2665).

Could we add to FanControl?

P.S Big fan.