### PR TITLE
add iCUE LINK Hub COMMANDER DUO device

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Support for the iCUE LINK Hub was added in v1.5.0. The following LINK devices ar
 | RX Fan                   | `13`       | `00`         | Full Support | ✅                | ✅                 | n/a              |
 | XD6 (Stealth Gray)       | `19`       | `00`         | Full Support | ✅                | ✅ <sup>1</sup>    | ✅               |
 | XD6 (White)              | `19`       | `01`         | Full Support | ✅                | ✅ <sup>1</sup>    | ✅               |
+| COMMANDER DUO            | `1b`       | `00`         | Full Support | ✅                | ✅                 | ✅               |
 
 Don't see your device listed? Open an [issue](https://github.com/EvanMulawski/FanControl.CorsairLink/issues) and provide a USB packet capture.
 

--- a/src/devices/icue_link/KnownLinkDevice.cs
+++ b/src/devices/icue_link/KnownLinkDevice.cs
@@ -37,6 +37,7 @@ public enum LinkDeviceModel : byte
     LiquidCoolerTitanSeries = 0x11,
     FanRxSeries = 0x13,
     PumpXd6Series = 0x19,
+    CommanderDuoSeries = 0x1b,
 }
 
 [Flags]

--- a/src/devices/icue_link/KnownLinkDevices.cs
+++ b/src/devices/icue_link/KnownLinkDevices.cs
@@ -33,6 +33,7 @@ public static class KnownLinkDevices
         _devices.Add(new KnownLinkDevice(LinkDeviceModel.CapSwapModuleVrmFan, 0x00, "VRM Fan CapSwap Module", LinkDeviceFlags.ControlsSpeed | LinkDeviceFlags.ReportsSpeed));
         _devices.Add(new KnownLinkDevice(LinkDeviceModel.PumpXd6Series, 0x00, "XD6", LinkDeviceFlags.All)); // stealth gray
         _devices.Add(new KnownLinkDevice(LinkDeviceModel.PumpXd6Series, 0x01, "XD6", LinkDeviceFlags.All)); // white
+        _devices.Add(new KnownLinkDevice(LinkDeviceModel.CommanderDuoSeries, 0x00, "COMMANDER DUO", LinkDeviceFlags.All));
 
         _deviceLookup = InitializeDeviceLookup();
     }


### PR DESCRIPTION
First, I'd like to thank you for making such a great plugin - it is truly awesome!

My previous Commander CORE-based AIO died and I replaced it with a new iCUE LINK Hub-based AIO.  I also replaced the old AIO's Commander CORE fan/temp controller with a new COMMANDER DUO controller, and plugged it into the LINK Hub.  These small changes make the DUO's temperature sensors and fan controls appear and work great in FanControl.

Thanks again!
