### PR TITLE
commander duo argb mode

### DIFF
--- a/src/FanControl.CorsairLink/HardwareIds.cs
+++ b/src/FanControl.CorsairLink/HardwareIds.cs
@@ -26,6 +26,7 @@ public static class HardwareIds
     public static readonly int CorsairHydroH150iProXTProductId = 0x0c22;
     public static readonly int CorsairHydroH60iProXTProductId = 0x0c29;
     public static readonly int CorsairCommanderCoreXTProductId = 0x0c2a;
+    public static readonly int CorsairCommanderDuoProductId = 0x0c56;
     public static readonly int CorsairHydroH100iProXT2ProductId = 0x0c2d;
     public static readonly int CorsairHydroH115iProXT2ProductId = 0x0c2e;
     public static readonly int CorsairHydroH150iProXT2ProductId = 0x0c2f;
@@ -78,6 +79,7 @@ public static class HardwareIds
         public static readonly IReadOnlyCollection<int> CommanderCore = new List<int>
         {
             CorsairCommanderCoreXTProductId,
+            CorsairCommanderDuoProductId,
         };
 
         public static readonly IReadOnlyCollection<int> CommanderCoreWithDesignatedPump = new List<int>

--- a/src/devices/commander_core/CommanderCoreDataReader.cs
+++ b/src/devices/commander_core/CommanderCoreDataReader.cs
@@ -29,9 +29,11 @@ public static class CommanderCoreDataReader
         {
             var currentSensor = sensorData.Slice(s, 2);
             var status = (CommanderCoreSpeedSensorStatus)connectedData[i];
-            int? rpm = status == CommanderCoreSpeedSensorStatus.Available
-                ? BinaryPrimitives.ReadInt16LittleEndian(currentSensor)
-                : null;
+            int? rpm =
+                status == CommanderCoreSpeedSensorStatus.Available ||
+                status == CommanderCoreSpeedSensorStatus.AvailableCommanderDuo
+                    ? BinaryPrimitives.ReadInt16LittleEndian(currentSensor)
+                    : null;
 
             sensors.Add(new CommanderCoreSpeedSensor(i, status, rpm));
         }

--- a/src/devices/commander_core/CommanderCoreSpeedSensor.cs
+++ b/src/devices/commander_core/CommanderCoreSpeedSensor.cs
@@ -17,5 +17,6 @@ public sealed class CommanderCoreSpeedSensor
 public enum CommanderCoreSpeedSensorStatus : byte
 {
     Available = 0x07,
+    AvailableCommanderDuo = 0x03,
     Unavailable = 0x01,
 }


### PR DESCRIPTION
- Support for Commander DUO ARGB Mode (`1b1c:0c56`)
- Added `AvailableCommanderDuo = 0x03` since DUO is using this value in order to detect connected fans.
- Added new pid `public static readonly int CorsairCommanderDuoProductId = 0x0c56;`
- Added new PID to:
```c#
        public static readonly IReadOnlyCollection<int> CommanderCore = new List<int>
        {
            CorsairCommanderCoreXTProductId,
            CorsairCommanderDuoProductId,
        };
```
- Changed how RPM is being read:
```c#
            int? rpm =
                status == CommanderCoreSpeedSensorStatus.Available ||
                status == CommanderCoreSpeedSensorStatus.AvailableCommanderDuo
                    ? BinaryPrimitives.ReadInt16LittleEndian(currentSensor)
                    : null;
```

<img width="943" height="775" alt="image" src="https://github.com/user-attachments/assets/8d9badc8-1cd0-4594-8c9f-4ff89b9d26f6" />