### PR TITLE
Target .NET 10 for the modern plugin build

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,12 +162,12 @@ Don't see your device listed? Open an [issue](https://github.com/EvanMulawski/Fa
 > All versions of this plugin prior to v1.7.0 require the .NET Framework build of Fan Control. Install Fan Control using the `FanControl_*_net_4_8.zip` release files or the `FanControl_*_net_4_8_Installer.exe` installer only.
 
 > [!NOTE]
-> Support for the .NET 8 build of Fan Control was added in v1.7.0-beta.1. As of this version, plugin builds are located within their respective directories. In step 4 below, the `FanControl.CorsairLink.dll` file will be located within the `net48` or `net8.0` directory. Choose the build that matches your Fan Control installation.
+> Support for the .NET build of Fan Control was added in v1.7.0-beta.1. As of this version, plugin builds are located within their respective directories. In step 4 below, the `FanControl.CorsairLink.dll` file will be located within the `net48` or `net10.0` directory. Choose the build that matches your Fan Control installation.
 
 1. Download a [release](https://github.com/EvanMulawski/FanControl.CorsairLink/releases).
 2. Unblock the downloaded ZIP file. (Right-click, Properties, check Unblock, OK)
 3. Exit Fan Control.
-4. Copy `FanControl.CorsairLink.dll` from the ZIP file to Fan Control's `Plugins` directory. Since v1.7.0-beta.1, the `FanControl.CorsairLink.dll` file will be located within the `net48` or `net8.0` directory. Choose the build that matches your Fan Control installation. If the `Plugins` directory does not exist where the Fan Control program is located, create it.
+4. Copy `FanControl.CorsairLink.dll` from the ZIP file to Fan Control's `Plugins` directory. Since v1.7.0-beta.1, the `FanControl.CorsairLink.dll` file will be located within the `net48` or `net10.0` directory. Choose the build that matches your Fan Control installation. If the `Plugins` directory does not exist where the Fan Control program is located, create it.
 5. Start Fan Control.
 
 ### SiUsbXpress Driver

--- a/src/CorsairLink.Synchronization/CorsairLink.Synchronization.csproj
+++ b/src/CorsairLink.Synchronization/CorsairLink.Synchronization.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net48;net8.0</TargetFrameworks>
+    <TargetFrameworks>net48;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>Latest</LangVersion>
@@ -9,10 +9,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\CorsairLink.Abstractions\CorsairLink.Abstractions.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
-    <PackageReference Include="System.Threading.AccessControl" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/FanControl.CorsairLink/FanControl.CorsairLink.csproj
+++ b/src/FanControl.CorsairLink/FanControl.CorsairLink.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net48;net8.0</TargetFrameworks>
+    <TargetFrameworks>net48;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>Latest</LangVersion>
@@ -34,7 +34,7 @@
       <HintPath>..\..\ref\FanControl.Plugins.dll</HintPath>
     </Reference>
     <PackageReference Include="ILRepack.Lib.MSBuild.Task" Version="2.0.33" />
-    <PackageReference Include="Microsoft.Win32.SystemEvents" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Win32.SystemEvents" Version="10.0.0" />
   </ItemGroup>
 
 </Project>

--- a/test/CorsairLink.Tests/CorsairLink.Tests.csproj
+++ b/test/CorsairLink.Tests/CorsairLink.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net48;net8.0</TargetFrameworks>
+    <TargetFrameworks>net48;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>Latest</LangVersion>


### PR DESCRIPTION
## Summary

Fan Control now ships a **.NET 10** build, so this retargets the modern plugin build from **net8.0 to net10.0**. The `net48` target is retained for the .NET Framework build of Fan Control, and the `netstandard2.0` device libraries are unchanged (they remain compatible with both targets).

## Changes

- Retarget `FanControl.CorsairLink`, `CorsairLink.Synchronization`, and the test project: `net48;net8.0` -> `net48;net10.0`.
- Bump `Microsoft.Win32.SystemEvents` `8.0.0` -> `10.0.0` to align with the runtime.
- Remove the explicit `System.Threading.AccessControl` package reference: it is now part of the .NET 10 shared framework (NU1510 flagged it as redundant), and the `net48` target never referenced it.
- Update the README install notes to reference the `net10.0` build directory instead of `net8.0`.

## Validation

- `dotnet build` succeeds for both `net48` and `net10.0` with no warnings.
- Full test suite passes on `net10.0` (58/58).

## Notes

Requires the .NET 10 SDK to build the modern target. Opened as a draft for maintainer review of the target-framework decision (keep `net48` + `net10.0` vs. any other combination).
